### PR TITLE
Library

### DIFF
--- a/operational-mocks.cabal
+++ b/operational-mocks.cabal
@@ -10,10 +10,11 @@ cabal-version:  >= 1.10
 library
   hs-source-dirs:
       src
+  ghc-options: -Wall
+
   build-depends:
       base
     , operational
-    , text
     , hspec
   exposed-modules:
       Control.Monad.Operational.Mocks
@@ -25,10 +26,11 @@ test-suite spec
   hs-source-dirs:
       test
     , src
+  ghc-options: -Wall
+
   build-depends:
       base
     , operational
-    , text
     , hspec
   other-modules:
       Control.Monad.Operational.MocksSpec

--- a/operational-mocks.cabal
+++ b/operational-mocks.cabal
@@ -1,0 +1,36 @@
+-- This file has been generated from package.yaml by hpack version 0.14.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           operational-mocks
+version:        0.1
+build-type:     Simple
+cabal-version:  >= 1.10
+
+library
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , operational
+    , text
+    , hspec
+  exposed-modules:
+      Control.Monad.Operational.Mocks
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs:
+      test
+    , src
+  build-depends:
+      base
+    , operational
+    , text
+    , hspec
+  other-modules:
+      Control.Monad.Operational.MocksSpec
+      Control.Monad.Operational.Mocks
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -4,8 +4,10 @@ version: "0.1"
 dependencies:
   - base
   - operational
-  - text
   - hspec
+
+ghc-options: >
+  -Wall
 
 tests:
   spec:

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,19 @@
+name: operational-mocks
+version: "0.1"
+
+dependencies:
+  - base
+  - operational
+  - text
+  - hspec
+
+tests:
+  spec:
+    main: Spec.hs
+    source-dirs:
+      - test
+      - src
+
+library:
+  source-dirs:
+    - src

--- a/src/Control/Monad/Operational/Mocks.hs
+++ b/src/Control/Monad/Operational/Mocks.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
 
+module Control.Monad.Operational.Mocks where
+
 import           Control.Monad
 import           Control.Monad.Operational
 import           Data.Functor

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-6.6
+packages:
+  - '.'
+extra-deps: []

--- a/test/Control/Monad/Operational/MocksSpec.hs
+++ b/test/Control/Monad/Operational/MocksSpec.hs
@@ -1,11 +1,61 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Control.Monad.Operational.MocksSpec where
 
+import           Control.Monad.Operational
+import           Data.Typeable
+import           Prelude hiding (getLine)
 import           Test.Hspec
 
 import           Control.Monad.Operational.Mocks
 
+spec :: Spec
 spec = do
-  describe "library" $ do
-    it "exists" $ do
-      return () :: IO ()
+  describe "testWithMock" $ do
+    it "allows to test against a sequence of primitive operations" $ do
+      testWithMock lineReverse $
+        GetLine :~> "foo" :>>>=
+        WriteLine "oof" :~> () :>>>=
+        Result ()
+
+    it "catches unexpected primitive calls" $ do
+      let test = testWithMock lineReverse $
+            GetLine :~> "foo" :>>>=
+            GetLine :~> "foo" :>>>=
+            Result ()
+      test `shouldThrow` errorCall "expected: call to GetLine, got: WriteLine"
+
+-- * primitives
+
+type TestProgram = Program TestPrim
+
+data TestPrim a where
+  GetLine :: TestPrim String
+  WriteLine :: String -> TestPrim ()
+
+deriving instance Show (TestPrim a)
+
+getLine :: TestProgram String
+getLine = singleton GetLine
+
+writeLine :: String -> TestProgram ()
+writeLine = singleton . WriteLine
+
+instance CommandEq TestPrim where
+  commandEq GetLine GetLine = Right Refl
+  commandEq (WriteLine a) (WriteLine b)
+    | a == b = Right Refl
+  commandEq a b = Left (showConstructor a, showConstructor b)
+
+  showConstructor = \ case
+    GetLine -> "GetLine"
+    WriteLine _ -> "WriteLine"
+
+-- * test programs
+
+lineReverse :: TestProgram ()
+lineReverse = do
+  l <- getLine
+  writeLine (reverse l)

--- a/test/Control/Monad/Operational/MocksSpec.hs
+++ b/test/Control/Monad/Operational/MocksSpec.hs
@@ -1,0 +1,11 @@
+
+module Control.Monad.Operational.MocksSpec where
+
+import           Test.Hspec
+
+import           Control.Monad.Operational.Mocks
+
+spec = do
+  describe "library" $ do
+    it "exists" $ do
+      return () :: IO ()

--- a/test/Control/Monad/Operational/MocksSpec.hs
+++ b/test/Control/Monad/Operational/MocksSpec.hs
@@ -16,14 +16,14 @@ spec = do
   describe "testWithMock" $ do
     it "allows to test against a sequence of primitive operations" $ do
       testWithMock lineReverse $
-        GetLine :~> "foo" :>>>=
-        WriteLine "oof" :~> () :>>>=
+        GetLine `returns` "foo" `andThen`
+        WriteLine "oof" `returns` () `andThen`
         Result ()
 
     it "catches unexpected primitive calls" $ do
       let test = testWithMock lineReverse $
-            GetLine :~> "foo" :>>>=
-            GetLine :~> "foo" :>>>=
+            GetLine `returns` "foo" `andThen`
+            GetLine `returns` "foo" `andThen`
             Result ()
       test `shouldThrow` errorCall "expected: call to GetLine, got: WriteLine"
 
@@ -47,7 +47,7 @@ instance CommandEq TestPrim where
   commandEq GetLine GetLine = Right Refl
   commandEq (WriteLine a) (WriteLine b)
     | a == b = Right Refl
-  commandEq a b = Left (showConstructor a, showConstructor b)
+  commandEq a b = Left ()
 
   showConstructor = \ case
     GetLine -> "GetLine"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
@amarpotghan: Please, review.

I wanted to call `:~>` `returning`, so that you use it inline:

``` haskell
  GetLine `returning` "foo" :>>>=
  ...
```

But I think you cannot mix infix operators and backtick-style infix functions like that (without brackets). Maybe you can figure that out.

Also I'm not sure about the name of `:>>>=`. Maybe `:>=` is better (like it was before). Also, we could pick any operator we want (i.e. doesn't have to start with `:`) by creating a simple alias for the constructor. But I think it'll be less easy to understand with an additional indirection. Any opinion on this?

Generally I'm not sure about the API of the mock DSL. Suggestions welcome.
