### PR TITLE
Add a convenient alias for andThen when primitives return unit

### DIFF
--- a/src/Control/Monad/Operational/Mocks.hs
+++ b/src/Control/Monad/Operational/Mocks.hs
@@ -29,10 +29,6 @@ andThen :: MockedPrimitive primitive a -> Mock primitive b -> Mock primitive b
 andThen = AndThen
 infixr 8 `andThen`
 
-andThen_ :: (ShowConstructor primitive, CommandEq primitive) => primitive () -> Mock primitive a -> Mock primitive a
-prim `andThen_` next = prim `returns` () `andThen` next
-infixr 8 `andThen_`
-
 data MockedPrimitive primitive a where
   TestPrimitive :: (forall a . primitive a -> IO (a :~: a')) -> a'
     -> MockedPrimitive primitive a'
@@ -58,10 +54,15 @@ testWithMock real mock = case (view real, mock) of
 
 -- * convenience
 
+andThen_ :: (ShowConstructor primitive, CommandEq primitive) =>
+  primitive () -> Mock primitive a -> Mock primitive a
+prim `andThen_` next = prim `returns` () `andThen` next
+infixr 8 `andThen_`
+
 returns :: forall mockResult primitive .
   (CommandEq primitive, ShowConstructor primitive) =>
   primitive mockResult -> mockResult -> MockedPrimitive primitive mockResult
-returns mockPrimitive mockResult = testPrimitive p mockResult
+returns mockPrimitive = testPrimitive p
   where
     p :: primitive realResult -> IO (realResult :~: mockResult)
     p realPrimitive = do

--- a/src/Control/Monad/Operational/Mocks.hs
+++ b/src/Control/Monad/Operational/Mocks.hs
@@ -29,6 +29,10 @@ andThen :: MockedPrimitive primitive a -> Mock primitive b -> Mock primitive b
 andThen = AndThen
 infixr 8 `andThen`
 
+andThen_ :: (ShowConstructor primitive, CommandEq primitive) => primitive () -> Mock primitive a -> Mock primitive a
+prim `andThen_` next = prim `returns` () `andThen` next
+infixr 8 `andThen_`
+
 data MockedPrimitive primitive a where
   TestPrimitive :: (forall a . primitive a -> IO (a :~: a')) -> a'
     -> MockedPrimitive primitive a'

--- a/test/Control/Monad/Operational/MocksSpec.hs
+++ b/test/Control/Monad/Operational/MocksSpec.hs
@@ -20,7 +20,7 @@ spec = do
     it "allows to test against a sequence of primitive operations" $ do
       testWithMock lineReverse $
         GetLine `returns` "foo" `andThen`
-        WriteLine "oof" `returns` () `andThen`
+        WriteLine "oof" `andThen_`
         result ()
 
     it "catches unexpected primitive calls" $ do
@@ -39,7 +39,7 @@ spec = do
     it "catches missing calls to primitives" $ do
       let test = testWithMock lineReverse $
             GetLine `returns` "foo" `andThen`
-            WriteLine "oof" `returns` () `andThen`
+            WriteLine "oof" `andThen_`
             GetLine `returns` "bar" `andThen`
             result ()
       test `shouldThrow` errorCall "expected: call to a primitive, got: function returns"
@@ -48,13 +48,13 @@ spec = do
       let forkedOutputMock :: TestPrimitive a -> IO (a :~: ())
           forkedOutputMock = \ case
             Fork forked -> do
-              let mock = (WriteLine "forked" `returns` () `andThen` result ())
+              let mock = (WriteLine "forked" `andThen_` result ())
               testWithMock forked mock
               return Refl
             _ -> throwIO $ ErrorCall "expected: Fork"
       testWithMock forkedOutput $
         testPrimitive forkedOutputMock () `andThen`
-        WriteLine "not forked" `returns` () `andThen`
+        WriteLine "not forked" `andThen_`
         result ()
 
 -- * primitives


### PR DESCRIPTION
@soenkehahn WDYT?
